### PR TITLE
fix: homepage design & structural fixes

### DIFF
--- a/src/bookmarks.html
+++ b/src/bookmarks.html
@@ -6,6 +6,15 @@
     <link href="styles.css" rel="stylesheet">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CL4HWBEGG6"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-CL4HWBEGG6');
+    </script>
 </head>
 <body>
     <div class="container">

--- a/src/bookmarks.html
+++ b/src/bookmarks.html
@@ -1,9 +1,11 @@
+<html lang="en">
 <head>
     <title>VICHOKO.cl</title>
-    <link href="https://fonts.googleapis.com/css?family=Share+Tech+Mono|Space+Mono|VT323|IBM+Plex+Mono&effect=anaglyph"
+    <link href="https://fonts.googleapis.com/css?family=Share+Tech+Mono|Space+Mono|VT323|IBM+Plex+Mono&effect=anaglyph&display=swap"
           rel="stylesheet">
     <link href="styles.css" rel="stylesheet">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
 </head>
 <body>
@@ -95,3 +97,4 @@ $(document).ready(function() {
 
 </script>
 </body>
+</html>

--- a/src/bookmarks.html
+++ b/src/bookmarks.html
@@ -6,7 +6,6 @@
     <link href="styles.css" rel="stylesheet">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
 </head>
 <body>
     <div class="container">
@@ -53,44 +52,53 @@
         </div>
     </div>
     <script>
-        $(function(){
-          $("#header").load("header.html");
-        });
+        fetch("header.html")
+          .then(r => r.text())
+          .then(h => document.getElementById("header").innerHTML = h);
     </script>
     <script>
-        $(function(){
-          $("#header").load("header.html");
-        });
-    </script>
-<script>
-$(document).ready(function() {
-    var toc = $("#toc").append($("<h2>Table of Contents</h2><ul></ul>"));
-    var lastLevel = 2;
+document.addEventListener("DOMContentLoaded", function() {
+    var toc = document.getElementById("toc");
+    var tocHeading = document.createElement("h2");
+    tocHeading.textContent = "Table of Contents";
+    toc.appendChild(tocHeading);
+    var headingUl = document.createElement("ul");
+    toc.appendChild(headingUl);
 
-    $("h2, h3").not("#toc h2, #toc h3").each(function(i) {
-        $(this).attr("id", "heading" + i);
+    var allHeadings = document.querySelectorAll("h2, h3");
+    var headings = [];
+    for (var i = 0; i < allHeadings.length; i++) {
+        if (!allHeadings[i].closest("#toc")) {
+            headings.push(allHeadings[i]);
+        }
+    }
+
+    headings.forEach(function(h, i) {
+        h.id = "heading" + i;
     });
 
-    $("h2, h3").not("#toc h2, #toc h3").each(function() {
-        var heading = $(this);
-        var level = parseInt(this.tagName.substring(1));
-        var listItem = $("<li></li>");
-        $("<a></a>").text(heading.text()).attr("href", "#" + heading.attr("id")).appendTo(listItem);
+    var lastLevel = 2;
+    headings.forEach(function(h) {
+        var level = parseInt(h.tagName.substring(1));
+        var li = document.createElement("li");
+        var a = document.createElement("a");
+        a.textContent = h.textContent;
+        a.href = "#" + h.id;
+        li.appendChild(a);
 
-        if (level == lastLevel) {
-            listItem.appendTo("#toc > ul");
+        if (level === lastLevel) {
+            headingUl.appendChild(li);
         } else if (level > lastLevel) {
-            var newUl = $("<ul></ul>");
-            $("#toc li:last").append(newUl);
-            listItem.appendTo(newUl);
+            var newUl = document.createElement("ul");
+            headingUl.lastElementChild.appendChild(newUl);
+            newUl.appendChild(li);
         } else {
-            listItem.appendTo("#toc > ul");
+            headingUl.appendChild(li);
         }
 
         lastLevel = level;
     });
 });
-
 </script>
 </body>
 </html>

--- a/src/bookmarks.html
+++ b/src/bookmarks.html
@@ -36,10 +36,6 @@
                 </li>
             </ul>
 
-            <h2>Geophysics</h2>
-            <ul>
-            </ul>
-
             <h2>Music</h2>
             <ul>
                 <li><a href="https://www.last.fm/user/Vichoko">Last.fm</a></li>

--- a/src/bookmarks/cidoo-v75.html
+++ b/src/bookmarks/cidoo-v75.html
@@ -6,7 +6,6 @@
     <link href="../styles.css" rel="stylesheet">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
     <style>
         table {
             border-collapse: collapse;
@@ -196,9 +195,9 @@
     </div>
 </div>
 <script>
-    $(function(){
-      $("#header").load("../header.html");
-    });
+    fetch("../header.html")
+      .then(r => r.text())
+      .then(h => document.getElementById("header").innerHTML = h);
 </script>
 </body>
 </html>

--- a/src/bookmarks/cidoo-v75.html
+++ b/src/bookmarks/cidoo-v75.html
@@ -1,10 +1,11 @@
-
+<html lang="en">
 <head>
     <title>VICHOKO.cl</title>
-    <link href="https://fonts.googleapis.com/css?family=Share+Tech+Mono|Space+Mono|VT323|IBM+Plex+Mono&effect=anaglyph"
+    <link href="https://fonts.googleapis.com/css?family=Share+Tech+Mono|Space+Mono|VT323|IBM+Plex+Mono&effect=anaglyph&display=swap"
           rel="stylesheet">
     <link href="../styles.css" rel="stylesheet">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
     <style>
         table {
@@ -200,3 +201,4 @@
     });
 </script>
 </body>
+</html>

--- a/src/bookmarks/cidoo-v75.html
+++ b/src/bookmarks/cidoo-v75.html
@@ -6,6 +6,15 @@
     <link href="../styles.css" rel="stylesheet">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CL4HWBEGG6"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-CL4HWBEGG6');
+    </script>
     <style>
         table {
             border-collapse: collapse;

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,15 @@
     <link href="styles.css" rel="stylesheet">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CL4HWBEGG6"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-CL4HWBEGG6');
+    </script>
 </head>
 
 <body>

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,6 @@
     <link href="styles.css" rel="stylesheet">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async
             src="https://www.googletagmanager.com/gtag/js?id=UA-127737963-1"></script>
@@ -31,9 +30,9 @@
     </div>
 </div>
 <script>
-    $(function(){
-      $("#header").load("header.html");
-    });
+    fetch("header.html")
+      .then(r => r.text())
+      .then(h => document.getElementById("header").innerHTML = h);
 </script>
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -6,19 +6,6 @@
     <link href="styles.css" rel="stylesheet">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async
-            src="https://www.googletagmanager.com/gtag/js?id=UA-127737963-1"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-
-        function gtag() {
-            dataLayer.push(arguments);
-        }
-
-        gtag('js', new Date());
-        gtag('config', 'UA-127737963-1');
-    </script>
 </head>
 
 <body>

--- a/src/index.html
+++ b/src/index.html
@@ -1,9 +1,11 @@
+<html lang="en">
 <head>
     <title>VICHOKO.cl</title>
-    <link href="https://fonts.googleapis.com/css?family=Share+Tech+Mono|Space+Mono|VT323|IBM+Plex+Mono&effect=anaglyph"
+    <link href="https://fonts.googleapis.com/css?family=Share+Tech+Mono|Space+Mono|VT323|IBM+Plex+Mono&effect=anaglyph&display=swap"
           rel="stylesheet">
     <link href="styles.css" rel="stylesheet">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async
@@ -34,3 +36,4 @@
     });
 </script>
 </body>
+</html>

--- a/src/me.html
+++ b/src/me.html
@@ -6,6 +6,15 @@
     <link href="styles.css" rel="stylesheet">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CL4HWBEGG6"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-CL4HWBEGG6');
+    </script>
 </head>
 
 <body>

--- a/src/me.html
+++ b/src/me.html
@@ -1,10 +1,11 @@
-
+<html lang="en">
 <head>
     <title>VICHOKO.cl</title>
-    <link href="https://fonts.googleapis.com/css?family=Share+Tech+Mono|Space+Mono|VT323|IBM+Plex+Mono&effect=anaglyph"
+    <link href="https://fonts.googleapis.com/css?family=Share+Tech+Mono|Space+Mono|VT323|IBM+Plex+Mono&effect=anaglyph&display=swap"
           rel="stylesheet">
     <link href="styles.css" rel="stylesheet">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
 </head>
 
@@ -25,3 +26,4 @@
     });
 </script>
 </body>
+</html>

--- a/src/me.html
+++ b/src/me.html
@@ -6,7 +6,6 @@
     <link href="styles.css" rel="stylesheet">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
 </head>
 
 <body>
@@ -21,9 +20,9 @@
     </div>
 </div>
 <script>
-    $(function(){
-      $("#header").load("header.html");
-    });
+    fetch("header.html")
+      .then(r => r.text())
+      .then(h => document.getElementById("header").innerHTML = h);
 </script>
 </body>
 </html>

--- a/src/styles.css
+++ b/src/styles.css
@@ -104,3 +104,27 @@ body {
 h3 {
     line-height: 0.9;
 }
+
+/* ---- Bookmarks Link Colors ---- */
+.paragraph a {
+    color: #66ff66;
+    text-decoration: none;
+}
+.paragraph a:hover {
+    background-color: #1a1a1a;
+    text-decoration: underline;
+}
+.paragraph a:visited {
+    color: #2d8a2d;
+}
+.paragraph a:active {
+    color: #99ff99;
+}
+
+.paragraph h2 {
+    margin-top: 1.5em;
+    margin-bottom: 0.3em;
+}
+.paragraph h3 {
+    margin-bottom: 0.2em;
+}


### PR DESCRIPTION
## Description

Comprehensive fix of structural and design issues across the homepage.

### Changes

**Task 1 — Structural HTML fixes (4 files)**
- Added `<html lang="en">` wrapper to all pages
- Added `<meta name="viewport">` for proper mobile rendering
- Added `&display=swap` to Google Fonts URLs (eliminates FOIT)
- Added `</html>` closing tags

**Task 2 — Link styling + cleanup (styles.css, bookmarks.html)**
- Replaced browser-default blue/purple link colors with lime palette (`#66ff66` default, `#2d8a2d` visited, hover background)
- Added heading spacing (`margin-top`/`margin-bottom` on h2/h3)
- Removed empty Geophysics section (placeholder sin contenido)

**Task 3 — jQuery removal + TOC rewrite (4 files)**
- Replaced jQuery 1.9.1 `.load("header.html")` with native `fetch()` (~90KB savings)
- Rewrote TOC generation script from jQuery to vanilla JS (was broken without jQuery)
- Removed duplicate header-load script from bookmarks.html

**Task 4 — Migrated Google Analytics from deprecated UA to GA4 (all 4 pages)**
- Removed UA-127737963-1 (Universal Analytics, discontinued July 2023)
- Added GA4 tag G-CL4HWBEGG6 on every page — index, me, bookmarks, cidoo-v75

### Files Changed
- `src/index.html` — structural + jQuery→fetch + GA: UA→GA4
- `src/me.html` — structural + jQuery→fetch + GA4 tag
- `src/bookmarks.html` — structural + Geophysics removal + jQuery→fetch + TOC rewrite + duplicate removal + GA4 tag
- `src/bookmarks/cidoo-v75.html` — structural + jQuery→fetch + GA4 tag
- `src/styles.css` — link colors + heading spacing